### PR TITLE
use proper user directory of NR for storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(RED)
         var thisNode = this;
 
         //Initialize persist storage
-        storage.initSync({dir: 'nodered/alexa-local/persist'});
+        storage.initSync({dir: `${RED.settings.userDir}/alexa-local/persist`});
 
         //Restore saved port number, if any
         //port == 0 when not available -> any available port (first time)


### PR DESCRIPTION
I don't run NR as root.  So, this was giving me fits:

```
Jan 05 16:54:03 marvin Node-RED[587]: 5 Jan 16:54:03 - [error] [alexa-local:54f55e9f.a8f28] Error: EACCES: permission denied, mkdir '/nodered'
Jan 05 16:54:03 marvin Node-RED[587]: at Object.fs.mkdirSync (fs.js:885:18)
Jan 05 16:54:03 marvin Node-RED[587]: at sync (/home/boneskull/.node-red/node_modules/mkdirp/index.js:71:13)
Jan 05 16:54:03 marvin Node-RED[587]: at sync (/home/boneskull/.node-red/node_modules/mkdirp/index.js:77:24)
Jan 05 16:54:03 marvin Node-RED[587]: at Function.sync (/home/boneskull/.node-red/node_modules/mkdirp/index.js:77:24)
Jan 05 16:54:03 marvin Node-RED[587]: at LocalStorage.parseStorageDirSync (/home/boneskull/.node-red/node_modules/node-red-contrib-alexa-local/node_modules/node-persist/src/local-storage.js:619:20)
Jan 05 16:54:03 marvin Node-RED[587]: at LocalStorage.initSync (/home/boneskull/.node-red/node_modules/node-red-contrib-alexa-local/node_modules/node-persist/src/local-storage.js:142:14)
Jan 05 16:54:03 marvin Node-RED[587]: at Object.nodePersist.initSync (/home/boneskull/.node-red/node_modules/node-red-contrib-alexa-local/node_modules/node-persist/src/node-persist.js:37:32)
Jan 05 16:54:03 marvin Node-RED[587]: at new AlexaLocalNode (/home/boneskull/.node-red/node_modules/node-red-contrib-alexa-local/index.js:19:17)
Jan 05 16:54:03 marvin Node-RED[587]: at createNode (/usr/lib/node_modules/node-red/red/runtime/nodes/flows/Flow.js:305:18)
Jan 05 16:54:03 marvin Node-RED[587]: at Flow.start (/usr/lib/node_modules/node-red/red/runtime/nodes/flows/Flow.js:89:35)
Jan 05 16:54:03 marvin Node-RED[587]: at start (/usr/lib/node_modules/node-red/red/runtime/nodes/flows/index.js:300:29)
Jan 05 16:54:03 marvin Node-RED[587]: at /usr/lib/node_modules/node-red/red/runtime/nodes/flows/index.js:137:21
Jan 05 16:54:03 marvin Node-RED[587]: at tryCatchReject (/usr/lib/node_modules/node-red/node_modules/when/lib/makePromise.js:845:30)
Jan 05 16:54:03 marvin Node-RED[587]: at runContinuation1 (/usr/lib/node_modules/node-red/node_modules/when/lib/makePromise.js:804:4)
Jan 05 16:54:03 marvin Node-RED[587]: at Fulfilled.when (/usr/lib/node_modules/node-red/node_modules/when/lib/makePromise.js:592:4)
Jan 05 16:54:03 marvin Node-RED[587]: at Pending.run (/usr/lib/node_modules/node-red/node_modules/when/lib/makePromise.js:483:13)
```

I've changed the storage dir to be under whatever the configured user dir is; in my case this works out to `~/.node-red/alexa-local/persist`.

