### PR TITLE
Decrease log verbosity

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,7 +273,7 @@ module.exports = function(RED)
         //Discovery XML
         else if (request.url == '/upnp/amazon-ha-bridge/setup.xml') 
         {
-            console.log("Sending setup.xml to " + request.connection.remoteAddress);
+            RED.log.debug("Sending setup.xml to " + request.connection.remoteAddress);
             thisNode.status({fill:"yellow", shape:"dot", text:"discovery (p:" + httpPort + ")"});
             var rawXml = constructBridgeSetupXml(lightId, deviceName, httpPort);
             response.writeHead(200, {'Content-Type': 'application/xml'});

--- a/index.js
+++ b/index.js
@@ -218,7 +218,7 @@ module.exports = function(RED)
         var authMatch = /^\/api\/(\w*)/.exec(request.url) && (request.method == 'POST');
 
         //Debug
-        console.log(lightId, deviceName, request.method, request.url, request.connection.remoteAddress);
+        RED.log.debug(lightId + ' ' + deviceName + ' ' + request.method + ' ' + request.url + ' ' + request.connection.remoteAddress)
 
         //Control 1 single light
         if (lightMatch)


### PR DESCRIPTION
Some `console.log` events occur to often to stay in the general output of the node-red server.
I used the node red built-in log feature for filtering.
https://nodered.org/docs/user-guide/logging

This allows the log messages to be seen when needed.
Fixes https://github.com/originallyus/node-red-contrib-alexa-local/issues/52